### PR TITLE
feat: update gemspec with erb_lint dependency and complete metadata

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,14 +2,59 @@ PATH
   remote: .
   specs:
     erb_lint-tailwindcss (0.1.0)
+      erb_lint (~> 0.4)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    actionview (8.0.2)
+      activesupport (= 8.0.2)
+      builder (~> 3.1)
+      erubi (~> 1.11)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    activesupport (8.0.2)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
     ast (2.4.3)
+    base64 (0.3.0)
+    benchmark (0.4.1)
+    better_html (2.1.1)
+      actionview (>= 6.0)
+      activesupport (>= 6.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      parser (>= 2.4)
+      smart_properties
+    bigdecimal (3.2.2)
+    builder (3.3.0)
+    concurrent-ruby (1.3.5)
+    connection_pool (2.5.3)
+    crass (1.0.6)
     date (3.4.1)
     diff-lcs (1.6.2)
+    drb (2.2.3)
     erb (5.0.1)
+    erb_lint (0.9.0)
+      activesupport
+      better_html (>= 2.0.1)
+      parser (>= 2.7.1.4)
+      rainbow
+      rubocop (>= 1)
+      smart_properties
+    erubi (1.13.1)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
     io-console (0.8.0)
     irb (1.15.2)
       pp (>= 0.6.0)
@@ -18,6 +63,13 @@ GEM
     json (2.12.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
+    logger (1.7.0)
+    loofah (2.24.1)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
+    minitest (5.25.5)
+    nokogiri (1.18.9-arm64-darwin)
+      racc (~> 1.4)
     parallel (1.27.0)
     parser (3.3.8.0)
       ast (~> 2.4.1)
@@ -30,6 +82,13 @@ GEM
       date
       stringio
     racc (1.8.1)
+    rails-dom-testing (2.3.0)
+      activesupport (>= 5.0.0)
+      minitest
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.6.2)
+      loofah (~> 2.21)
+      nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     rainbow (3.1.1)
     rake (13.3.0)
     rdoc (6.14.2)
@@ -66,14 +125,18 @@ GEM
       parser (>= 3.3.7.2)
       prism (~> 1.4)
     ruby-progressbar (1.13.0)
+    securerandom (0.4.1)
+    smart_properties (1.17.0)
     stringio (3.1.7)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
+    uri (1.0.3)
 
 PLATFORMS
   arm64-darwin-24
-  ruby
 
 DEPENDENCIES
   erb_lint-tailwindcss!

--- a/erb_lint-tailwindcss.gemspec
+++ b/erb_lint-tailwindcss.gemspec
@@ -8,17 +8,19 @@ Gem::Specification.new do |spec|
   spec.authors = ["okonomi"]
   spec.email = ["okonomi@oknm.jp"]
 
-  spec.summary = "TODO: Write a short summary, because RubyGems requires one."
-  spec.description = "TODO: Write a longer description or delete this line."
-  spec.homepage = "TODO: Put your gem's website or public repo URL here."
+  spec.summary = "ERB Lint plugin for Tailwind CSS class ordering, deduplication, and validation"
+  spec.description = "A gem that provides ERB Lint rules for Tailwind CSS classes, " \
+                     "including class ordering, duplicate detection, and unknown class validation " \
+                     "with autocorrect support."
+  spec.homepage = "https://github.com/okonomi/erb_lint-tailwindcss"
   spec.license = "MIT"
   spec.required_ruby_version = ">= 3.1.0"
 
-  spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
+  spec.metadata["allowed_push_host"] = "https://rubygems.org"
 
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "TODO: Put your gem's public repo URL here."
-  spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
+  spec.metadata["source_code_uri"] = "https://github.com/okonomi/erb_lint-tailwindcss"
+  spec.metadata["changelog_uri"] = "https://github.com/okonomi/erb_lint-tailwindcss/blob/main/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
@@ -33,8 +35,8 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  # Uncomment to register a new dependency of your gem
-  # spec.add_dependency "example-gem", "~> 1.0"
+  # Runtime dependencies
+  spec.add_dependency "erb_lint", "~> 0.4"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/spec/erb_lint/tailwindcss_spec.rb
+++ b/spec/erb_lint/tailwindcss_spec.rb
@@ -5,7 +5,12 @@ RSpec.describe ErbLint::Tailwindcss do
     expect(ErbLint::Tailwindcss::VERSION).not_to be nil
   end
 
-  it "does something useful" do
-    expect(false).to eq(true)
+  it "can be required without errors" do
+    expect { require "erb_lint/tailwindcss" }.not_to raise_error
+  end
+
+  it "defines the correct module hierarchy" do
+    expect(ErbLint::Tailwindcss).to be_a(Module)
+    expect(ErbLint::Tailwindcss::Error).to be < StandardError
   end
 end


### PR DESCRIPTION
## Summary
- Add `erb_lint ~> 0.4` as runtime dependency to enable ERB linting functionality
- Complete gemspec metadata with proper summary, description, and repository URLs
- Add basic require tests to validate gem loads correctly and module hierarchy
- Fix RuboCop line length issues in gemspec

## Test plan
- [x] Tests pass (`bundle exec rspec`)
- [x] RuboCop passes (`bundle exec rubocop`)
- [x] Gem can be required without errors
- [x] Module hierarchy is properly defined

🤖 Generated with [Claude Code](https://claude.ai/code)